### PR TITLE
Fix rename of contributor image property name

### DIFF
--- a/content/_data/publication.yaml
+++ b/content/_data/publication.yaml
@@ -56,7 +56,7 @@ contributor:
     affiliation: J. Paul Getty Museum
     bio: "Judith Keller joined the J. Paul Getty Museum in 1986 and since 2008 was an Associate Curator of Photographs. In 2010, she was named the Senior Curator of Photographs. Keller received her B.A. in Art History and a Masters in Museum Practice and Art History from the University of Michigan at Ann Arbor. She also completed course work for a Phd. in Art History at the University of Michigan. Prior to her tenure at the Getty, Keller worked at The University of Michigan Museum of Art (1979 – 1981) and at the Archer M. Huntington Art Gallery (now the Blanton Museum of Art) at The University of Texas, Austin, as Curator of Prints and Drawings."
     url: https://news.getty.edu/judith-keller-named-senior-curator-photographs-at-j-paul-getty-museum.htm
-    pic: contributors/judith-keller.jpg
+    image: contributors/judith-keller.jpg
   - id: dlange
     type: secondary
     first_name: Dorothea
@@ -65,7 +65,7 @@ contributor:
     affiliation: Farm Security Administration
     bio: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
     url: https://en.wikipedia.org/wiki/Dorothea_Lange
-    pic: figures/lange.jpg
+    image: figures/lange.jpg
   - id: wevans
     type: secondary
     first_name: Walker
@@ -74,7 +74,7 @@ contributor:
     affiliation: Farm Security Administration
     bio: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
     url: https://en.wikipedia.org/wiki/Walker_Evans
-    pic: figures/evans.jpg
+    image: figures/evans.jpg
 
 # ------------------------------------------------------------------------------
 # Copright & License


### PR DESCRIPTION
Was not yet synced with rename in the contributor shortcode. RIP `pic`.