### PR TITLE
Update `@thegetty/quire-11ty` peer dependency to `latest`

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
   },
   "homepage": "https://quire.getty.edu/",
   "peerDependencies": {
-    "@thegetty/quire-11ty": "^1.0.0-pre-release.8"
+    "@thegetty/quire-11ty": "latest"
   }
 }


### PR DESCRIPTION
Updating `@thegetty/quire-11ty` to `latest` in package file `peerDependencies` will mitigate the need to manually update the version of `@thegetty/quire-11ty`