### PR TITLE
Add epub build artifact to ignore patterns 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,27 @@
-# Eleventy
+# Eleventy build artifacts
+_epub/
+_pdf/
 _site/
-public/
+_temp/
 
-# dotenv environment variables file
+# EleventFetch cache directory
+.cache
+
+# Environment variables
 .env
 .env.*
 !.env.example
 
+# ESLint cache directory
+.eslintcache
+
 # Dependency directories
 node_modules/
 
-# Log files
+# Local Netlify folder
+.netlify
+
+# log files
 logs
 *.log
 lerna-debug.log*
@@ -18,7 +29,7 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-# Optional npm cache directory
+# npm cache directory
 .npm
 
 # Runtime data
@@ -27,13 +38,8 @@ pids
 *.seed
 *.pid.lock
 
-# Optional eslint cache
-.eslintcache
-
-# Local Netlify folder
-.netlify
-
-# OS-specific directory files
-.DS_store
+# System files
+.DS_Store
 desktop.ini
 thumbs.db
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thegetty/quire-starter-default",
-  "version": "1.0.0-pre-release.0",
+  "version": "1.0.0-pre-release.1",
   "description": "Quire's default project template",
   "repository": {
     "type": "git",


### PR DESCRIPTION
`EleventyWatcher` will ignore files that match `.gitignore` patterns; adding `_epub` to the Eleventy build artifacts that are ignored by git and allows these build artifacts without triggering an endless rebuild and reload of the page when running `quire preview`.

## Changes

- Adds `_epub` to gitignore patterns
- Aligns the `quire-starter-default` and `quire-11ty` `.gitignore` files
- Updates pre-release version
