### PR TITLE
Remove reset link handling

### DIFF
--- a/content/_assets/javascript/application/canvas-panel.js
+++ b/content/_assets/javascript/application/canvas-panel.js
@@ -79,24 +79,6 @@ const goToFigureState = function ({ annotationIds=[], figureId, region }) {
   }
 
   /**
-   * Update reset link state
-   */
-  const resetLink = figure.querySelector('.q-figure__reset-link')
-  if (resetLink && region) {
-    const disabledLinkClass = 'q-figure__reset-link--disabled'
-    const clickHandler = () => {
-      resetLink.classList.add(disabledLinkClass)
-      update(serviceId, { region: 'reset' })
-    }
-    if (region === 'reset') {
-      resetLink.removeEventListener('click', clickHandler)
-    } else {
-      resetLink.classList.remove(disabledLinkClass)
-      resetLink.addEventListener('click', clickHandler)
-    }
-  }
-
-  /**
    * Update figure state
    */
   update(serviceId, { annotations, region: region || 'reset' })


### PR DESCRIPTION
The reset button was previously removed until we have a new design for it, but the JS for handling reset was still here causing an annorefs to images in the entry page viewer to fail. Cleanin' up.