### PR TITLE
DEV-13197: Setup `@font-face` imports with relative paths for print output

### DIFF
--- a/content/_assets/styles/assets-dir-print.scss
+++ b/content/_assets/styles/assets-dir-print.scss
@@ -1,0 +1,1 @@
+$assets-dir: "_assets/" !default;

--- a/content/_assets/styles/assets-dir.scss
+++ b/content/_assets/styles/assets-dir.scss
@@ -1,0 +1,1 @@
+$assets-dir: "/_assets/" !default;

--- a/content/_assets/styles/fonts.scss
+++ b/content/_assets/styles/fonts.scss
@@ -2,7 +2,12 @@
 // Fonts.scss
 // -----------------------------------------------------------------------------
 // Custom font declarations (if any) can be imported here
-$assets-dir: "/_assets/" !default;
+@media screen {
+  @import "assets-dir"
+}
+@media print {
+  @import "assets-dir-print"
+}
 
 @function font($file) {
   @return url($assets-dir + 'fonts/' + $file);


### PR DESCRIPTION
see https://github.com/thegetty/quire/pull/649

These media query-specific imports were necessary as declaring media query-specific `$assets-dir` paths does not work:

``` scss
@media screen {
  $assets-dir: "/_assets/" !default !global;
}
@media print {
  $assets-dir: "_assets/" !default !global;
}

```