### PR TITLE
Fix canonicalURL handling of paths

### DIFF
--- a/content/_computed/eleventyComputed.js
+++ b/content/_computed/eleventyComputed.js
@@ -8,10 +8,9 @@ const { warn } = chalkFactory('eleventyComputed')
  */
 module.exports = {
   canonicalURL: ({ publication, page }) => {
-    const { url } = publication
-    const { origin, pathname } = new URL(url)
-    const pagePath = path.join(pathname, page.url)
-    return new URL(pagePath, origin).href
+    let { url } = publication
+    url += url.endsWith('/') ? '' : '/'
+    return new URL(page.url, url).href
   },
   eleventyNavigation: {
     /**

--- a/content/_computed/eleventyComputed.js
+++ b/content/_computed/eleventyComputed.js
@@ -7,7 +7,12 @@ const { warn } = chalkFactory('eleventyComputed')
  * Global computed data
  */
 module.exports = {
-  canonicalURL: ({ publication, page }) => page.url && path.join(publication.url, page.url),
+  canonicalURL: ({ publication, page }) => {
+    const { url } = publication
+    const { origin, pathname } = new URL(url)
+    const pagePath = path.join(pathname, page.url)
+    return new URL(pagePath, origin).href
+  },
   eleventyNavigation: {
     /**
      * Explicitly define page data properties used in the TOC


### PR DESCRIPTION
Update canonicalURL property to use `URL` constructor instead of `path.join`. Validation of the `url` will happen upstream.