### PR TITLE
Update CanonicalURL 

### DIFF
--- a/content/_computed/eleventyComputed.js
+++ b/content/_computed/eleventyComputed.js
@@ -8,9 +8,8 @@ const { warn } = chalkFactory('eleventyComputed')
  */
 module.exports = {
   canonicalURL: ({ publication, page }) => {
-    let { url } = publication
-    url += url.endsWith('/') ? '' : '/'
-    return new URL(page.url, url).href
+    const pageUrl = page.url.replace(/^\/+/, '')
+    return new URL(pageUrl, publication.url).href
   },
   eleventyNavigation: {
     /**


### PR DESCRIPTION
Changes:
- Publication.url validation will now be happening upstream, so removing adding of trailing slash
- Remove _leading_ slash from page.url so that URLs are formatteded