### PR TITLE
Fix: PDF page layout and headings

### DIFF
--- a/content/_assets/styles/components/quire-menu.scss
+++ b/content/_assets/styles/components/quire-menu.scss
@@ -54,7 +54,13 @@
       font-style: italic;
     }
 
-    h1, h2, h3, h4, h5, h6 { color: $quire-menu-text-color; }
+    h1, h2, h3, h4, h5, h6 { 
+      color: $quire-menu-text-color; 
+      font-family: $quire-headings-font;
+      @if $quire-headings-font == $ibm-sans {
+        letter-spacing: -0.025em;
+      }
+    }
 
   }
   

--- a/content/_assets/styles/components/quire-page.scss
+++ b/content/_assets/styles/components/quire-page.scss
@@ -62,6 +62,10 @@ html {
     @media print {
       color: $print-text-color;
     }
+    font-family: $quire-headings-font;
+    @if $quire-headings-font == $ibm-sans {
+      letter-spacing: -0.025em;
+    }
 
     &:not(:first-child) {
       margin-top: 1rem;

--- a/content/_assets/styles/components/quire-page.scss
+++ b/content/_assets/styles/components/quire-page.scss
@@ -42,7 +42,14 @@ html {
 // .quire-page
 // -----------------------------------------------------------------------------
 .quire-page {
-  min-height: calc(100vh - #{$navbar-height} - #{$quire-progress-bar-height});
+
+  @media screen {
+    min-height: calc(100vh - #{$navbar-height} - #{$quire-progress-bar-height});
+  }
+  @media print {
+    min-height: calc($print-height - $print-top-margin - $print-bottom-margin);
+    page-break-before: always;
+  }
 
   h1,
   h2,

--- a/content/_assets/styles/layout.scss
+++ b/content/_assets/styles/layout.scss
@@ -33,18 +33,6 @@
 .quire {
   width: 100%;
 
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6 {
-    font-family: $quire-headings-font;
-    @if $quire-headings-font == $ibm-sans {
-      letter-spacing: -0.025em;
-    }
-  }
-
   // Styles used whether JS is enabled or not
   main {
     background-color: $secondary-background-color;
@@ -173,14 +161,6 @@
         }
       }
     }
-  }
-
-  .is-pulled-right {
-    float: right;
-  }
-
-  .is-pulled-left {
-    float: left;
   }
 }
 

--- a/content/_assets/styles/print.scss
+++ b/content/_assets/styles/print.scss
@@ -12,14 +12,10 @@
 
 // Variables (others in the variables.scss file)
 // -----------------------------------------------------------------------------
-$print-base-text-column-width: 4.75in;
+$print-base-text-column-width: ($print-width - $print-inner-margin - $print-outer-margin) * .7;
 
 @if $print-width <= 7 {
-  $print-inner-margin: $print-width - $print-base-text-column-width - $print-outer-margin;
-}
-
-@if $print-height <= 10 {
-  $print-top-margin: 0.5in;
+  $print-base-text-column-width: $print-width - $print-inner-margin - $print-outer-margin;
 }
 
 $print-footer-font: $quire-headings-font;

--- a/content/_assets/styles/print.scss
+++ b/content/_assets/styles/print.scss
@@ -14,11 +14,6 @@
 // -----------------------------------------------------------------------------
 $print-base-text-column-width: 4.75in;
 
-$print-bottom-margin: 0.875in;
-$print-top-margin: 0.75in;
-$print-outer-margin: 0.75in;
-$print-inner-margin: 1in;
-
 @if $print-width <= 7 {
   $print-inner-margin: $print-width - $print-base-text-column-width - $print-outer-margin;
 }

--- a/content/_assets/styles/print.scss
+++ b/content/_assets/styles/print.scss
@@ -189,6 +189,7 @@ $print-trim: $print-bleed * 2;
   }
   h2, h3, h4, h5, h6 {
     prince-bookmark-level: none;
+    page-break-after: avoid;
   }
 
 // Generated content for footers and page #s in TOC

--- a/content/_assets/styles/utilities.scss
+++ b/content/_assets/styles/utilities.scss
@@ -151,6 +151,14 @@ sub {
   }
 }
 
+.is-pulled-right {
+  float: right;
+}
+
+.is-pulled-left {
+  float: left;
+}
+
 .overflow-container {
   overflow: scroll;
   box-sizing: border-box;

--- a/content/_assets/styles/variables.scss
+++ b/content/_assets/styles/variables.scss
@@ -61,6 +61,11 @@ $print-width: 8.5in;
 $print-height: 11in;
 $print-bleed: .125in;
 
+$print-bottom-margin: 0.875in;
+$print-top-margin: 0.75in;
+$print-outer-margin: 0.75in;
+$print-inner-margin: 1in;
+
 $print-base-font-size: 8.5pt;
 $print-text-color: $black;
 

--- a/content/essay.md
+++ b/content/essay.md
@@ -11,18 +11,6 @@ abstract: |
   Excerpt from *Walker Evans: Catalogue of the Collection* (1995) by Judith Keller. Available for free download in its entirety, in the Getty Publications [Virtual Library](https://www.getty.edu/publications/virtuallibrary/0892363177.html).
 ---
 
-# Heading One
-
-## Heading Two
-
-### Heading Three
-
-#### Heading Four
-
-##### Heading Five
-
-###### Heading Six
-
 When Evans was officially hired in October 1935 as an Information Specialist by the Historical Section of the Resettlement Administration, his duties were described as follows: "Under the general supervision of the Chief of the Historical Section with wide latitude for the exercise of independent judgement and decision as Senior Information Specialist to carry out special assignments in the field; collect, compile and create photographic material to illustrate factual and interpretive news releases and other informational material upon all problems, progress and activities of the Resettlement Administration."[^1] Evans was to make liberal use of his right to exercise "independent judgement" during his time with the RA, and he perpetually resisted the idea that his purpose there was to gather illustrations for the promotion of the RA's (that is, the federal government's New Deal) programs. While considering a position with the RA in the spring of 1935, he jotted down those things he would require of his employer, including the "guarantee of one-man performance," and what he would provide, adding that he should not be asked to do anything more in the way of political propaganda: "[I] Mean never [to] make photographic statements for the government or do photographic chores for gov or anyone in gov, no matter how powerful—this is pure record not propaganda. The value and, if you like, even the propaganda value for the government lies in the record itself which in the long run will prove an intelligent and farsighted thing to have done. NO POLITICS whatever." ({% cite 'Evans 1938' %})
 
 {% figure 'vid-1' %}

--- a/content/essay.md
+++ b/content/essay.md
@@ -11,6 +11,18 @@ abstract: |
   Excerpt from *Walker Evans: Catalogue of the Collection* (1995) by Judith Keller. Available for free download in its entirety, in the Getty Publications [Virtual Library](https://www.getty.edu/publications/virtuallibrary/0892363177.html).
 ---
 
+# Heading One
+
+## Heading Two
+
+### Heading Three
+
+#### Heading Four
+
+##### Heading Five
+
+###### Heading Six
+
 When Evans was officially hired in October 1935 as an Information Specialist by the Historical Section of the Resettlement Administration, his duties were described as follows: "Under the general supervision of the Chief of the Historical Section with wide latitude for the exercise of independent judgement and decision as Senior Information Specialist to carry out special assignments in the field; collect, compile and create photographic material to illustrate factual and interpretive news releases and other informational material upon all problems, progress and activities of the Resettlement Administration."[^1] Evans was to make liberal use of his right to exercise "independent judgement" during his time with the RA, and he perpetually resisted the idea that his purpose there was to gather illustrations for the promotion of the RA's (that is, the federal government's New Deal) programs. While considering a position with the RA in the spring of 1935, he jotted down those things he would require of his employer, including the "guarantee of one-man performance," and what he would provide, adding that he should not be asked to do anything more in the way of political propaganda: "[I] Mean never [to] make photographic statements for the government or do photographic chores for gov or anyone in gov, no matter how powerful—this is pure record not propaganda. The value and, if you like, even the propaganda value for the government lies in the record itself which in the long run will prove an intelligent and farsighted thing to have done. NO POLITICS whatever." ({% cite 'Evans 1938' %})
 
 {% figure 'vid-1' %}


### PR DESCRIPTION
This is the first of several PRs related to the PDF output. This one makes some needed fixes to the heading styles, and to the general layout handling.

Of particular note, the `min-height` value set for the screen version was causing trouble in paged.js layouts in particular, so we're now defining a height for screen _and_ for print, giving us the right page flow and breaks in PDF.

Also, there were some heading styles and a couple figure utility classes that were attached to the `.quire` class, but this class is a top-level DIV that isn't part of the PDF layout.html (and doesn't need to be), so I moved those to a more sensible place to work for both screen and pdf.

In this and in the forthcoming PDF PRs, I've tested everything in both PrinceXML and paged.js with the goal of getting their outputs as identical as possible.