### PR TITLE
Fix: pdf table of contents and page footers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,26 @@ Project versions conform to [Semantic Versioning](https://semver.org/)
 * `Fixed`: for any bug fixes
 - `Removed`: for deprecated features removed in this release
 
-[1.0.0-pre-release]
+## [1.2.0]
 
-## 1.1.0
+### Added
 
-* Fixed styles for headings and the page height for the PDF outputs.
-- Changed location of SCSS variables for pdf margins to variables.scss file
+- Dotted leaders in table of contents for PrinceXML
+
+### Fixed
+
+* Use of base-font-size variables
+* Page footers in PDF
+
+## [1.1.0]
+
+### Changed
+
+* Location of SCSS variables for pdf margins
+
+### Fixed
+
+* CSS styles for headings
+* Page height for the PDF outputs
+
+## [1.0.0-pre-release]

--- a/content/_assets/styles/components/quire-buttons.scss
+++ b/content/_assets/styles/components/quire-buttons.scss
@@ -29,7 +29,7 @@
     border-radius: 2px;
     -webkit-transition: all .25s ease;
     transition: all .25s ease;
-    font-size: $quire-base-font-size;
+    font-size: 1rem;
     border: 1px solid button-color($content-background-color);
     color: button-color($content-background-color);
 
@@ -40,7 +40,7 @@
       margin-top: 0;
       padding-top: .6em;
       font-family: $quire-navigation-font;
-      font-size: $quire-base-font-size;
+      font-size: 1rem;
     }
 
     &.prev {

--- a/content/_assets/styles/components/quire-contents-list.scss
+++ b/content/_assets/styles/components/quire-contents-list.scss
@@ -64,15 +64,15 @@
     width: 100%;
     &.page-item {
       .title {
-        font-size: $quire-base-font-size;
+        font-size: 1rem;
         a {
-          font-size: $quire-base-font-size;
+          font-size: 1rem;
         }
       }
       .abstract-text {
-        font-size: $quire-base-font-size * 0.875;
+        font-size: 0.875rem;
         @media print {
-          font-size: $print-base-font-size;
+          font-size: 1rem;
         }
       }
     }
@@ -95,14 +95,14 @@
   }
 
   .menu-list {
-    font-size: $quire-base-font-size;
+    font-size: 1rem;
     a {
       padding: 0;
     }
 
     .section-header {
       text-align: center;
-      font-size: $quire-base-font-size !important;
+      font-size: 1rem !important;
       border-top: 1px solid background-color($content-background-color);
       padding-top: 3.3375em;
       margin-bottom: 0;
@@ -161,7 +161,7 @@
       font-family: $quire-headings-font;
       color: background-color-text($secondary-background-color);
       @media print {
-        font-size: $print-base-font-size;
+        font-size: 1rem;
         color: $print-text-color;
       }
     }
@@ -182,7 +182,7 @@
       padding-right: 0;
       font-size: 1.375em;
       @media print {
-        font-size: $print-base-font-size;
+        font-size: 1rem;
         color: $print-text-color;
       }
       -webkit-transition: all .25s ease;
@@ -267,7 +267,7 @@
     .abstract-text {
       font-size: 0.875em;
       @media print {
-        font-size: $print-base-font-size;
+        font-size: 1rem;
       }
       line-height: 1.5em;
       margin-top: 0.375rem;
@@ -292,7 +292,7 @@
       }
       .abstract-text {
         @media print {
-          font-size: $print-base-font-size;
+          font-size: 1rem;
         }
       }
     }
@@ -473,7 +473,7 @@
     ol li {
       float: left;
       width: 100%;
-      font-size: $quire-base-font-size;
+      font-size: 1rem;
 
       @media screen and (min-width: $desktop) {
         width: 50%;
@@ -545,14 +545,14 @@
       }
 
       .card.image {
-        font-size: $quire-base-font-size;
+        font-size: 1rem;
         .card-content {
           font-size: 1.125em;
           padding: 1.5em;
         }
       }
       .card.no-image {
-        font-size: $quire-base-font-size;
+        font-size: 1rem;
         .card-content {
           font-size: 2rem;
           @media print {
@@ -569,7 +569,7 @@
       }
 
       a {
-        font-size: $quire-base-font-size;
+        font-size: 1rem;
       }
 
       .card-content {

--- a/content/_assets/styles/components/quire-page.scss
+++ b/content/_assets/styles/components/quire-page.scss
@@ -49,6 +49,9 @@ html {
   @media print {
     min-height: calc($print-height - $print-top-margin - $print-bottom-margin);
     page-break-before: always;
+    // enable use of :first page selector on all @pages
+    // https://www.princexml.com/doc/paged/#page-groups
+    prince-page-group: start;
   }
 
   h1,

--- a/content/_assets/styles/components/quire-popup.scss
+++ b/content/_assets/styles/components/quire-popup.scss
@@ -18,7 +18,7 @@ div {
 
     > span {
       font-family: $font_0;
-      font-size: $quire-base-font-size;
+      font-size: 1rem;
       font-weight: bold;
     }
   }

--- a/content/_assets/styles/print.scss
+++ b/content/_assets/styles/print.scss
@@ -191,11 +191,7 @@ $print-trim: $print-bleed * 2;
 // Generated content for footers and page #s in TOC
 // -----------------------------------------------------------------------------
   .quire-page {
-    string-set: pagetitle attr(data-footer-page-title);
-  }
-
-  .quire-page {
-    string-set: sectiontitle attr(data-footer-section-title);
+    string-set: pagetitle attr(data-footer-page-title), sectiontitle attr(data-footer-section-title);
   }
 
   // Adds page numbering with dotted leaders in PrinceXML

--- a/content/_assets/styles/print.scss
+++ b/content/_assets/styles/print.scss
@@ -198,25 +198,49 @@ $print-trim: $print-bleed * 2;
     string-set: sectiontitle attr(data-footer-section-title);
   }
 
+  // Adds page numbering with dotted leaders in PrinceXML
+  // uses .pagedjs_pages class to handle fallback in Paged.js
   .quire-contents-list {
+    .section-item > a {
+      max-width: 90%;
+    }
+    .section-item > a::after {
+      content: leader(dotted) ' 'target-counter(attr(href, url), page);
+      margin-left: 6pt;
+      margin-right: -10%;
+      .pagedjs_pages & {
+        content: target-counter(attr(href), page);
+        float: right;
+      }
+    }
+    .section-item.frontmatter-page > a::after {
+      content: leader(dotted) ' 'target-counter(attr(href, url), page, lower-roman);
+      font-style: italic;
+      .pagedjs_pages & {
+        content: target-counter(attr(href), page, lower-roman);
+        float: right;
+      }
+    }
     .page-item {
       max-width: 90%;
       a::after {
-        content: target-counter(attr(href), page);
+        content: leader(dotted) ' 'target-counter(attr(href, url), page);
         margin-left: 6pt;
         margin-right: -10%;
-        // This border is a hack for PrinceXML which doesn't
-        // otherwise recognize the box sizing for some reason
-        border: 1pt solid transparent;
+        .pagedjs_pages & {
+          content: target-counter(attr(href), page);
+          float: right;
+        }
       }
-      &.frontmatter-page a::after {
-        content: target-counter(attr(href), page, lower-roman);
+      &.frontmatter-page > a::after {
+        content: leader(dotted) ' 'target-counter(attr(href, url), page, lower-roman);
         font-style: italic;
         margin-left: 6pt;
         margin-right: -10%;
-        // This border is a hack for PrinceXML which doesn't
-        // otherwise recognize the box sizing for some reason
-        border: 1pt solid transparent;
+        .pagedjs_pages & {
+          content: target-counter(attr(href), page, lower-roman);
+          float: right;
+        }
       }
     }
     &.grid {

--- a/content/_assets/styles/print.scss
+++ b/content/_assets/styles/print.scss
@@ -165,12 +165,6 @@ $print-trim: $print-bleed * 2;
     }
   }
 
-  @page page-one:first {
-    @bottom-left {
-      content: none;
-    }
-  }
-
   @page :blank {
     @bottom-left {
       content: none;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thegetty/quire-starter-default",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Quire's default project template",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This is a another set of fixes for the PDF output:

- adds dotted leaders back in for the PrinceXML output, with a fallback for paged.js
- fixes the overuse of a couple base-font-size variables that were causing inheritance issues
- fixes a couple issues related to the running footers in the PDF

@mphstudios I added to the CHANGELOG and fixed up the formatting per your comment in PR #22. Let me know if it needs other tweaks.