### PR TITLE
Ensure `q-modal` figures are not obscured by `q-lightbox` figures on catalog pages

### DIFF
--- a/content/_assets/styles/components/q-modal.scss
+++ b/content/_assets/styles/components/q-modal.scss
@@ -1,6 +1,6 @@
 q-modal {
   position: fixed;
-  z-index: 1;
+  z-index: 10;
   top: 0;
   left: 0;
   width: 100vw;


### PR DESCRIPTION
A `z-index: 10` was previously added to the `div.quire-entry__image-wrap`; this update adds the same z-index to the `q-modal` styles to ensure that modal figures are not obscured by lightbox figures on catalog pages
