### PR TITLE
Rename class frontmatter property to classes

### DIFF
--- a/content/essay.md
+++ b/content/essay.md
@@ -4,7 +4,8 @@ title: American Photographs
 subtitle: Evans in Middletown
 layout: essay
 order: 30
-class: page-one
+classes:
+  - page-one
 contributor:
   - id: jkeller
 abstract: |

--- a/content/pdf-epub-copyright.md
+++ b/content/pdf-epub-copyright.md
@@ -1,7 +1,8 @@
 ---
 layout: page
 order: 5
-class: copyright-page
+classes:
+  - copyright-page
 outputs:
   - epub
   - pdf

--- a/content/pdf-epub-half-title.md
+++ b/content/pdf-epub-half-title.md
@@ -1,6 +1,7 @@
 ---
 layout: base.11ty.js
-class: half-title-page
+classes:
+  - half-title-page
 order: 2
 outputs:
   - epub

--- a/content/pdf-epub-title.md
+++ b/content/pdf-epub-title.md
@@ -1,6 +1,7 @@
 ---
 layout: base.11ty.js
-class: title-page
+classes:
+  - title-page
 order: 3
 outputs:
   - pdf


### PR DESCRIPTION
Avoid using reserved word `class` and creates consistency with the frontmatter and computed property.

Fixes [Quire#722](https://github.com/thegetty/quire/issues/722) 

This branch should be merged prior to the relevant work in the main quire repo.