### PR TITLE
Ensure `objects-page` gets an off-white background color

### DIFF
--- a/content/_assets/styles/print.scss
+++ b/content/_assets/styles/print.scss
@@ -111,6 +111,10 @@ $print-trim: $print-bleed * 2;
     }
   }
 
+  @page objects {
+    background-color: $print-splash-color;
+  }
+
   @page splash {
     background-color: $print-splash-color;
   }
@@ -275,6 +279,10 @@ $print-trim: $print-bleed * 2;
   .title-page,
   .copyright-page {
     page: no-footer;
+  }
+
+  .objects-page {
+    page: objects;
   }
 
   .quire-splash {


### PR DESCRIPTION
I couldn't push the same update to https://github.com/thegetty/quire-starter-objects-test/ as I don't have write permissions on that repo, but this just ensures the `.object-page` section gets its own page with an off-white background so the cards look nice.
