### PR TITLE
Refine visibility toggle for lightbox slides

### DIFF
--- a/content/_assets/styles/components/q-lightbox-slides.scss
+++ b/content/_assets/styles/components/q-lightbox-slides.scss
@@ -17,10 +17,11 @@
   .q-lightbox-slides__slide {
     transform: translateY(100%);
     opacity: 0;
-    display: none:
+    display: none;
     transition: transform 0s 0.4s, opacity 0.4s linear;
 
-    &[data-lightbox-near-current] {
+    &[data-lightbox-preload] {
+      // Laid-out but transparent so component load events fire 
       display: block;
     }
 

--- a/content/_assets/styles/components/q-lightbox-slides.scss
+++ b/content/_assets/styles/components/q-lightbox-slides.scss
@@ -17,11 +17,17 @@
   .q-lightbox-slides__slide {
     transform: translateY(100%);
     opacity: 0;
+    display: none:
     transition: transform 0s 0.4s, opacity 0.4s linear;
+
+    &[data-lightbox-near-current] {
+      display: block;
+    }
 
     &[data-lightbox-current] {
       transform: translateY(0);
       opacity: 1;
+      display: block;
       transition: transform 0s, opacity 0.4s linear;
     }
   }


### PR DESCRIPTION
This PR adds `display:block`/`display:none` to selectors that handle current slide visibility. It also adds a selector `.data-lightbox-near-current` to allow slides to be laid out (and thus load their contents) without being seen for, eg, image and IIIF prefetching.