### PR TITLE
Bump quire-starter-default package version number and changelog to 2.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ Project versions conform to [Semantic Versioning](https://semver.org/)
 * `Fixed`: for any bug fixes
 - `Removed`: for deprecated features removed in this release
 
+## [2.9.2]
+
+### Fixed
+
+- Adds `display: none` to lightbox slide styles that use `opacity: none`
+
+### Changed
+
+- Adds `lightbox-slide-preload` selectors to lightbox styles
+- Adds bulma visibility helpers (`is-hidden`, etc) to CSS bundle
+
 ## [2.9.0]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Project versions conform to [Semantic Versioning](https://semver.org/)
 * `Fixed`: for any bug fixes
 - `Removed`: for deprecated features removed in this release
 
-## [2.9.2]
+## [2.9.1]
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thegetty/quire-starter-default",
-  "version": "2.9.0",
+  "version": "2.9.2",
   "description": "Quire's default project template",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thegetty/quire-starter-default",
-  "version": "2.9.2",
+  "version": "2.9.1",
   "description": "Quire's default project template",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR updates the quire-starter-default package number to reflect the most recent merges to this repo.