### PR TITLE
Fix starter style issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ Project versions conform to [Semantic Versioning](https://semver.org/)
 * `Fixed`: for any bug fixes
 - `Removed`: for deprecated features removed in this release
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed height being applied to page in PDF output on side-by-side entry pages
+- Alignment of navigation buttons in Safari
+
 ## [2.9.0]
 
 ### Fixed

--- a/content/_assets/styles/components/quire-buttons.scss
+++ b/content/_assets/styles/components/quire-buttons.scss
@@ -22,7 +22,7 @@
 
   li.quire-nav-button {
     display: inline-block;
-    width: 9.25em;
+    min-width: 9.25em;
     height: 2.9em;
     -moz-border-radius: 2px;
     -webkit-border-radius: 2px;

--- a/content/_assets/styles/components/quire-entry.scss
+++ b/content/_assets/styles/components/quire-entry.scss
@@ -662,12 +662,14 @@ $image-divider-height: 16px;
     }
 
     div.quire-entry__content {
-      overflow: scroll;
-      width: 100%;
-      height: calc(
-        ((100vh - #{$navbar-height} - #{$quire-progress-bar-height}) * 0.55) -
-          $image-divider-height
-      );
+      @media screen {
+        overflow: scroll;
+        width: 100%;
+        height: calc(
+          ((100vh - #{$navbar-height} - #{$quire-progress-bar-height}) * 0.55) -
+            $image-divider-height
+        );
+      }
 
       @media screen and (min-width: $desktop) {
         height: 100vh;


### PR DESCRIPTION
This addresses two small issues from the backlog: [DEV-20187](https://jira.getty.edu/browse/DEV-20187) and [DEV-18251](https://jira.getty.edu/browse/DEV-18251).

@mphstudios, Let me know if this is the right handling of the CHANGELOG. My assumption is that when anyone submits a PR, they should update the CHANGELOG under `[Unreleased]`. It would then be up to the maintainers (you and I) to determine when to number and publish that release, and only then would we add a version number to the CHANGELOG and to package.json. Is that correct?