### PR TITLE
Add objects page demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Project versions conform to [Semantic Versioning](https://semver.org/)
 
 ## [Unreleased]
 
+### Added
+
+- Include demo of `objects-page` for catalogue, in place of `table-of-contents` grid
+
 ### Fixed
 
 - Fixed height being applied to page in PDF output on side-by-side entry pages

--- a/content/_data/objects.yaml
+++ b/content/_data/objects.yaml
@@ -1,3 +1,12 @@
+object_filters:
+  - artist
+  - year
+
+object_card:
+  - thumbnail
+  - id
+  - title
+
 object_display_order:
   - artist
   - year
@@ -7,8 +16,8 @@ object_display_order:
 
 object_list:
 
-  - id: 1
-    title: Human Erosion in California / Migrant Mother
+  - id: "1"
+    title: "*Human Erosion in California / Migrant Mother*"
     artist: Dorothea Lange
     year: 1936
     medium: Gelatin silver print
@@ -18,8 +27,8 @@ object_list:
     figure:
       - id: "cat-1"
 
-  - id: 2
-    title: Bud Fields and His Wife Ivy, and His Daughter Ellen, Hale County, Alabama
+  - id: "2"
+    title: "*Bud Fields and His Wife Ivy, and His Daughter Ellen, Hale County, Alabama*"
     artist: Walker Evans
     year: 1936
     medium: Gelatin silver print

--- a/content/catalogue/1.md
+++ b/content/catalogue/1.md
@@ -6,7 +6,7 @@ layout: entry
 order: 101
 presentation: side-by-side
 object:
-  - id: 1
+  - id: "1"
 ---
 
 The first publication of this renowned image occurred on March 11, 1936, on the third day that the San Francisco News ran a story about the pea pickers’ camp at Nipomo. It was also featured as a full-page reproduction in September 1936 issue of *Survey Graphic*, titled “Draggin’-Around People” and captioned “A blighted pea crop in California in 1935 left the pickers without work. This family sold their tent to get food.” Also in this issue was an article by Taylor entitled “From the Group Up.” His report on demonstration projects of the New Deal’s Resettlement Administration in Arizona, Utah, New Mexico, and California was illustrated with four more picture by Lange.

--- a/content/catalogue/2.md
+++ b/content/catalogue/2.md
@@ -5,7 +5,7 @@ short_title: The Fields Family
 layout: entry
 order: 103
 object:
-  - id: 2
+  - id: "2"
 ---
 
 From mid-July to mid-September 1936, Evans took a leave from his position as an information specialist for the Historical Section of the Resettlement Administration to work with the writer James Agee on an assignment for *Fortune* magazine. They traveled to the Deep South to prepare an article on tenant cotton farming. In Alabama they documented the lives of farmers, including the Fields family. Evans found in this average American household the archetypal portrait of the everyman that he treasured. The straight-forward style of this portrait emphasizes the family's hard life as much as their pride.

--- a/content/catalogue/index.md
+++ b/content/catalogue/index.md
@@ -1,7 +1,5 @@
 ---
-epub: false
 title: Catalogue
-layout: table-of-contents
-presentation: grid
+layout: objects-page
 order: 100
 ---


### PR DESCRIPTION
The starter was still using the older display method for the catalogue page:

```
layout: table-of-contents
presentation: grid
```

This updates the starter to instead use `layout: objects-page` with object filtering.