### PR TITLE
fix/Quire lightbox slide area to allow outside click modal close

### DIFF
--- a/content/_assets/styles/components/q-lightbox-slides.scss
+++ b/content/_assets/styles/components/q-lightbox-slides.scss
@@ -34,6 +34,13 @@
       opacity: 1;
       display: block;
       transition: transform 0s, opacity 0.4s linear;
+
+      img.q-figure__image {
+        max-width: 100%;
+        max-height: 100%;
+        width: auto;
+        height: auto;
+      }
     }
   }
 

--- a/content/_assets/styles/components/quire-page.scss
+++ b/content/_assets/styles/components/quire-page.scss
@@ -599,8 +599,16 @@ html {
 
 // Download link defaults
 .quire-download__link {
-  color: if($theme == classic,$black,$accent-color);
-  fill: if($theme == classic,$black,$accent-color);
+  @if $theme == classic { 
+    color: $black;
+  } @else {
+    color: $accent-color;
+  }
+  @if $theme == classic {
+    fill: $black;
+  } @else {
+    fill: $accent-color;
+  }
   font-size: 0.875rem;
 
   span {
@@ -620,8 +628,16 @@ html {
     margin: 1.5rem auto 0;
 
     &:hover {
-      color: if($theme == classic,$accent-color,link-hover-color($secondary-background-color));
-      fill: if($theme == classic,$accent-color,link-hover-color($secondary-background-color));
+      @if $theme == classic {
+        color: $accent-color;
+      } @else {
+        color: link-hover-color($secondary-background-color);
+      };
+      @if $theme == classic {
+        fill: $accent-color;
+      } @else {
+        fill: link-hover-color($secondary-background-color);
+      };
     }
     .quire-download__link__icon {
       height: 1rem;
@@ -656,8 +672,16 @@ html {
 
     .quire-download__link {
       &:hover {
-        color: if($theme == classic,$accent-color,link-hover-color($content-background-color));
-        fill: if($theme == classic,$accent-color,link-hover-color($content-background-color));
+        @if $theme == classic {
+          color: $accent-color;
+        } @else {
+          color: link-hover-color($content-background-color);
+        };
+        @if $theme == classic {
+          fill: $accent-color;
+        } @else {
+          fill: link-hover-color($content-background-color);
+        };
       }
       .quire-download__link__icon {
         height: 0.875rem;


### PR DESCRIPTION
This change adds a style to the quire light-box slide `.q-lightbox-slides_slide`. Previously, the image within the slide was inheriting the parent's size `width/height 100%`. By adding this style, we set the image back to its intrinsic value set to auto. This avoids introducing custom CSS overrides. 

As a side fix, updated sass if-else from its deprecated syntax to its modern one.