### PR TITLE
Ensure `media_id` is a string

### DIFF
--- a/content/_data/figures.yaml
+++ b/content/_data/figures.yaml
@@ -67,7 +67,7 @@ figure_list:
     media_type: table
 
   - id: "audio-1"
-    media_id: 748443409
+    media_id: "748443409"
     media_type: soundcloud
     label: "Audio 1"
     caption: "*Modern Art Notes Podcast*, episode 429, “Dorothea Lange, Soul of a Nation,” hosted by Tyler Green, https://soundcloud.com/manpodcast/ep429."


### PR DESCRIPTION
This pull request wraps the `media_id` of the example soundcloud figure to ensure correctness and match the validation schema.