### PR TITLE
Update bylineFormat options in config.yaml

### DIFF
--- a/content/_data/config.yaml
+++ b/content/_data/config.yaml
@@ -11,7 +11,7 @@ accordion:
 analytics:
   googleId: ''
 
-bylineFormat: name-title # name | name-title | false
+bylineFormat: name-title # initials | name | name-title | string | false
 
 bibliography:
   displayOnPage: true


### PR DESCRIPTION
`bylineFormat` can accept more options than we'd noted in the YAML file comment. We've updated the Quire docs site, and making the change here as well to be consistent